### PR TITLE
fix: syntax for `git issueb` now uses shell command

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -7,4 +7,4 @@
 	editor = nvim -f
 [alias]
 	rw = commit --amend -m
-	issueb = git branch | grep
+	issueb = !git branch | grep


### PR DESCRIPTION
Without this, git fails to process the pipe which helps you find the issue name using grep